### PR TITLE
feat: addition of activate template POST api endpoint for when template versions get updated

### DIFF
--- a/sdk/template_version.go
+++ b/sdk/template_version.go
@@ -92,6 +92,24 @@ func (c *Client) UpdateTemplateVersion(ctx context.Context, t TemplateVersion) (
 	return parseTemplateVersion(respBody)
 }
 
+// ActivateTemplateVersion activates a version of a transactional template and returns it.
+func (c *Client) ActivateTemplateVersion(ctx context.Context, t TemplateVersion) (*TemplateVersion, error) {
+	if t.ID == "" {
+		return nil, ErrTemplateVersionIDRequired
+	}
+
+	if t.TemplateID == "" {
+		return nil, ErrTemplateIDRequired
+	}
+
+	respBody, _, err := c.Post(ctx, "POST", "/templates/"+t.TemplateID+"/versions/"+t.ID+"/activate", t)
+	if err != nil {
+		return nil, fmt.Errorf("failed activating template version: %w", err)
+	}
+
+	return parseTemplateVersion(respBody)
+}
+
 // DeleteTemplateVersion deletes a version of a transactional template.
 func (c *Client) DeleteTemplateVersion(ctx context.Context, templateID, id string) (bool, error) {
 	if templateID == "" {

--- a/sendgrid/resource_sendgrid_template_version.go
+++ b/sendgrid/resource_sendgrid_template_version.go
@@ -215,6 +215,12 @@ func resourceSendgridTemplateVersionUpdate(
 		templateVersion.Active = d.Get("active").(int)
 	}
 
+	if templateVersion.Active == 1 {
+		if _, err := c.ActivateTemplateVersion(ctx, templateVersion); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("name") {
 		templateVersion.Name = d.Get("name").(string)
 	}


### PR DESCRIPTION
Looking to add a feature here so that the template gets set to active. There's a current bug in which a template gets updated in the provider but does not get get updated/set to active even through a successful Terraform apply.

This is the API that's currently being used to update the SendGrid Template Versions: https://docs.sendgrid.com/api-reference/transactional-templates-versions/edit-a-transactional-template-version

This is the additional API that I'm looking to add in. https://docs.sendgrid.com/api-reference/transactional-templates-versions/activate-a-transactional-template-version

Please advise on the recommended configuration here!

Thanks!