### PR TITLE
Fixes a deprecated error and sendgrid_template_version problem.

### DIFF
--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -136,17 +136,17 @@ func RetryOnRateLimit(
 ) (interface{}, error) {
 	var resp interface{}
 
-	err := resource.RetryContext(
+	err := retry.RetryContext(
 		ctx,
-		d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 			var requestErr RequestError
 			resp, requestErr = f()
 			if requestErr.Err != nil {
 				if requestErr.StatusCode == http.StatusTooManyRequests {
-					return resource.RetryableError(requestErr.Err)
+					return retry.RetryableError(requestErr.Err)
 				}
 
-				return resource.NonRetryableError(requestErr.Err)
+				return retry.NonRetryableError(requestErr.Err)
 			}
 
 			return nil

--- a/sendgrid/resource_sendgrid_template_version.go
+++ b/sendgrid/resource_sendgrid_template_version.go
@@ -127,6 +127,7 @@ func resourceSendgridTemplateVersionCreate(ctx context.Context, d *schema.Resour
 		Active:               d.Get("active").(int),
 		Name:                 d.Get("name").(string),
 		HTMLContent:          d.Get("html_content").(string),
+		PlainContent:         d.Get("plain_content").(string),
 		GeneratePlainContent: d.Get("generate_plain_content").(bool),
 		Subject:              d.Get("subject").(string),
 		Editor:               d.Get("editor").(string),
@@ -227,6 +228,10 @@ func resourceSendgridTemplateVersionUpdate(
 
 	if d.HasChange("html_content") {
 		templateVersion.HTMLContent = d.Get("html_content").(string)
+	}
+
+	if d.HasChange("plain_content") {
+		templateVersion.PlainContent = d.Get("plain_content").(string)
 	}
 
 	if d.HasChange("generate_plain_content") {


### PR DESCRIPTION
- Fixes deprecated errors reported by golangci-lint
- Fixes problem where plain_content was not being sent when creating or updating sendgrid_template_version.