### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,6 @@
 name: golangci-lint
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/anna-money/terraform-provider-sendgrid/security/code-scanning/2](https://github.com/anna-money/terraform-provider-sendgrid/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Since this workflow is for linting and does not modify the repository, the `contents: read` permission is sufficient. This change will ensure that the workflow only has read access to the repository contents, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
