### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: release
+permissions:
+  contents: read
+  packages: read
+  statuses: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/anna-money/terraform-provider-sendgrid/security/code-scanning/1](https://github.com/anna-money/terraform-provider-sendgrid/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required for the workflow. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for repository content access.
- `packages: read` for interacting with packages if necessary.
- `id-token: write` for fetching OpenID Connect tokens if required by external tools.
- `statuses: write` for updating commit statuses.

The permissions block should be added at the top level of the workflow file to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
